### PR TITLE
updating R version as R-4.1.0-win.exe isn't available anymore

### DIFF
--- a/carpenpi/urls.py
+++ b/carpenpi/urls.py
@@ -1,7 +1,7 @@
 #URLs
-url = 'https://cran.r-project.org/bin/windows/base/R-4.1.0-win.exe'
+url = 'https://cran.r-project.org/bin/windows/base/R-4.1.1-win.exe'
 urlgen='https://cran.r-project.org/bin/windows/base/release.html'
-url2 = 'https://cran.r-project.org/bin/macosx/base/R-4.1.0.pkg'
+url2 = 'https://cran.r-project.org/bin/macosx/base/R-4.1.1.pkg'
 url3 = 'https://download1.rstudio.org/desktop/windows/RStudio-1.4.1106.exe'
 url4 = 'https://download1.rstudio.org/desktop/macos/RStudio-1.4.1106.dmg'
 urls = [url, url2, url3, url4]


### PR DESCRIPTION
https://cran.r-project.org/bin/windows/base/R-4.1.0-win.exe gives an error 404 and stops the download. Updating it to R-4.1.1-win.exe works. Updating the MacOS version for consistency.